### PR TITLE
Minor typos in entity_manager

### DIFF
--- a/src/entity_manager/manager.py
+++ b/src/entity_manager/manager.py
@@ -53,6 +53,8 @@ class Entity_Manager(object):
 			if not label in dictionary_labels:
 				dictionary_labels.append(label)
 			data['skos_prefLabel_ss'].append(label)
+		if not len(prefLabels):
+			data['skos_prefLabel_ss'] = [preferred_label]
 		data['skos_prefLabel_txt'] = data['skos_prefLabel_ss']
 
 		data['label_ss'] = []

--- a/src/entity_manager/manager.py
+++ b/src/entity_manager/manager.py
@@ -34,10 +34,10 @@ class Entity_Manager(object):
 		if preferred_label:
 			dictionary_labels.append(preferred_label)
 		else:
-			if len(pref_Labels):
-				preferred_label = pref_Lables[0]
+			if len(prefLabels):
+				preferred_label = prefLabels[0]
 			elif len(labels):
-				preferred_label = lables[0]
+				preferred_label = labels[0]
 			else:
 				preferred_label = id
 


### PR DESCRIPTION
When prefLabels is set to its default value of [] then data['skos_prefLabel_ss'] and data['skos_prefLabel_txt'] will be equal to [].

The proposed addition fixes that

-----------------
EDIT: The above is invalid but there are some minor variable name typos