### PR TITLE
Adding label_txt to qf when querying solr for correct label to apply

### DIFF
--- a/src/entity_linking/entity_linker.py
+++ b/src/entity_linking/entity_linker.py
@@ -69,6 +69,7 @@ class Entity_Linker(object):
 				'wt': 'json',
 				'defType': 'edismax',
 				'qf': [	'label_ss',
+						'label_txt',
 						'preferred_label_s^10',
 						'preferred_label_txt^5',
 						'skos_prefLabel_ss^10',


### PR DESCRIPTION
label_txt isn't in the list of queried field. This is an issue because label_ss doesn't have the lower case filter applied to it. 